### PR TITLE
Add one trivial type ValidatorSet for execution layer to pass and impl corresponding converter function

### DIFF
--- a/crates/api-types/src/on_chain_config/mod.rs
+++ b/crates/api-types/src/on_chain_config/mod.rs
@@ -4,7 +4,7 @@
 // mod jwk_consensus_config;
 // pub mod randomness_api_v0_config;
 // mod randomness_config;
-// mod validator_set;
+pub mod validator_set;
 pub mod validator_info;
 pub mod validator_config;
 pub mod consensus_config;

--- a/crates/api-types/src/on_chain_config/validator_info.rs
+++ b/crates/api-types/src/on_chain_config/validator_info.rs
@@ -27,9 +27,9 @@ pub struct ValidatorInfo {
     // initial property.
     pub account_address: AccountAddress,
     // Voting power of this validator
-    consensus_voting_power: u64,
+    pub consensus_voting_power: u64,
     // Validator config
-    config: ValidatorConfig,
+    pub config: ValidatorConfig,
 }
 
 impl fmt::Display for ValidatorInfo {

--- a/crates/api-types/src/on_chain_config/validator_set.rs
+++ b/crates/api-types/src/on_chain_config/validator_set.rs
@@ -1,0 +1,15 @@
+use serde::{Deserialize, Serialize};
+
+use crate::on_chain_config::validator_info::ValidatorInfo;
+
+// Just to represent one memory layout for other repo to pass
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+// #[cfg_attr(any(test, feature = "fuzzing"))]
+pub struct ValidatorSet {
+    pub active_validators: Vec<ValidatorInfo>,
+    pub pending_inactive: Vec<ValidatorInfo>,
+    pub pending_active: Vec<ValidatorInfo>,
+    pub total_voting_power: u128,
+    pub total_joining_power: u128,
+}

--- a/types/src/idl/api_types_converter.rs
+++ b/types/src/idl/api_types_converter.rs
@@ -1,0 +1,248 @@
+// Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Converter module for converting between api-types and gravity-aptos types
+//!
+//! This module provides conversion functions to transform ValidatorInfo and ValidatorConfig
+//! from the api-types crate to the corresponding types in gravity-aptos.
+
+use super::error::ValidatorInfoIdlError;
+use crate::{
+    account_address::AccountAddress,
+    network_address::NetworkAddress,
+    on_chain_config::{ConsensusScheme, ValidatorSet},
+    validator_config::ValidatorConfig,
+    validator_info::ValidatorInfo,
+};
+use anyhow::{anyhow, format_err};
+use aptos_crypto::bls12381;
+use bytes::Bytes;
+use std::{convert::TryFrom, str::FromStr};
+
+// Convert the bytes returned from execution layer
+// In greth, it returnes one gravity_validator_set bytes
+pub fn construct_and_convert_validator_set(
+    bytes: &[u8],
+) -> Result<ValidatorSet, ValidatorInfoIdlError> {
+    let validator_set =
+        bcs::from_bytes::<api_types::on_chain_config::validator_set::ValidatorSet>(bytes)
+            .map_err(|e| format_err!("[on-chain config] Failed to deserialize into config: {}", e))
+            .unwrap();
+    let validator_set = convert_validator_set(validator_set)?;
+    Ok(validator_set)
+}
+
+pub fn convert_validator_set(
+    api_validator_set: api_types::on_chain_config::validator_set::ValidatorSet,
+) -> Result<ValidatorSet, ValidatorInfoIdlError> {
+    // Convert validator set
+    let active_validators = api_validator_set
+        .active_validators
+        .iter()
+        .map(|validator| convert_validator_info(validator))
+        .collect::<Result<Vec<ValidatorInfo>, ValidatorInfoIdlError>>()?;
+    let pending_inactive = api_validator_set
+        .pending_inactive
+        .iter()
+        .map(|validator| convert_validator_info(validator))
+        .collect::<Result<Vec<ValidatorInfo>, ValidatorInfoIdlError>>()?;
+    let pending_active = api_validator_set
+        .pending_active
+        .iter()
+        .map(|validator| convert_validator_info(validator))
+        .collect::<Result<Vec<ValidatorInfo>, ValidatorInfoIdlError>>()?;
+    let total_voting_power = api_validator_set.total_voting_power;
+    let total_joining_power = api_validator_set.total_joining_power;
+
+    Ok(ValidatorSet {
+        scheme: ConsensusScheme::BLS12381,
+        active_validators,
+        pending_inactive,
+        pending_active,
+        total_voting_power,
+        total_joining_power,
+    })
+}
+
+/// Convert api-types ValidatorInfo to gravity-aptos ValidatorInfo
+///
+/// This function handles the conversion between the two different ValidatorInfo
+/// implementations, ensuring type safety and proper error handling.
+///
+/// ## Example
+///
+/// ```rust
+/// use aptos_types::idl::api_types_converter::convert_validator_info;
+///
+/// // Assuming you have an api_types::ValidatorInfo instance
+/// let api_validator_info: api_types::ValidatorInfo = /* from api */;
+///
+/// // Convert to gravity-aptos ValidatorInfo
+/// let gravity_validator_info = convert_validator_info(&api_validator_info)?;
+/// ```
+pub fn convert_validator_info(
+    api_validator_info: &api_types::on_chain_config::validator_info::ValidatorInfo,
+) -> Result<ValidatorInfo, ValidatorInfoIdlError> {
+    // Convert account address
+    let account_address = convert_account_address(&api_validator_info.account_address)?;
+
+    // Convert validator config
+    let config = convert_validator_config(&api_validator_info.config)?;
+
+    // Create gravity-aptos ValidatorInfo
+    Ok(ValidatorInfo::new(
+        account_address,
+        api_validator_info.consensus_voting_power,
+        config,
+    ))
+}
+
+// TODO(Gravity_alex): we should consider multi addresses in one validator config
+fn parse_network_address(
+    network_addresses: Vec<u8>,
+) -> Result<Vec<NetworkAddress>, ValidatorInfoIdlError> {
+    let address_bytes = Bytes::from(network_addresses);
+    let address_string: String = bcs::from_bytes(&address_bytes).unwrap();
+    let validator_network_address: NetworkAddress =
+        NetworkAddress::from_str(&address_string).unwrap();
+    Ok(vec![validator_network_address])
+}
+
+/// Convert api-types ValidatorConfig to gravity-aptos ValidatorConfig
+pub fn convert_validator_config(
+    api_config: &api_types::on_chain_config::validator_config::ValidatorConfig,
+) -> Result<ValidatorConfig, ValidatorInfoIdlError> {
+    // Convert consensus public key from Vec<u8> to bls12381::PublicKey
+    // let consensus_public_key =
+    //     bls12381::PublicKey::try_from(api_config.consensus_public_key.as_slice())
+    //         .map_err(|e| ValidatorInfoIdlError::ConsensusPublicKeyError(e.to_string()))?;
+
+    let consensus_public_key = bls12381::PublicKey::try_from(
+        hex::decode(&api_config.consensus_public_key)
+            .unwrap()
+            .as_slice(),
+    )
+    .map_err(|e| ValidatorInfoIdlError::ConsensusPublicKeyError(e.to_string()))?;
+
+    let validator_network_addresses = bcs::to_bytes(
+        &parse_network_address(api_config.validator_network_addresses.clone()).unwrap(),
+    )
+    .unwrap();
+    let fullnode_network_addresses = bcs::to_bytes(
+        &parse_network_address(api_config.fullnode_network_addresses.clone()).unwrap(),
+    )
+    .unwrap();
+
+    Ok(ValidatorConfig::new(
+        consensus_public_key,
+        validator_network_addresses,
+        fullnode_network_addresses,
+        api_config.validator_index,
+    ))
+}
+
+/// Convert api-types AccountAddress to gravity-aptos AccountAddress
+pub fn convert_account_address(
+    api_address: &api_types::u256_define::AccountAddress,
+) -> Result<AccountAddress, ValidatorInfoIdlError> {
+    // api_types::AccountAddress is a wrapper around [u8; 32]
+    // gravity-aptos::AccountAddress is also [u8; 32]
+    // We can convert directly
+    let bytes: [u8; 32] = api_address.bytes();
+    Ok(AccountAddress::new(bytes))
+}
+
+/// Convert gravity-aptos ValidatorInfo to api-types ValidatorInfo
+///
+/// This is the reverse conversion, useful when you need to convert back
+/// to api-types format for API responses.
+pub fn convert_to_api_validator_info(
+    validator_info: &ValidatorInfo,
+) -> api_types::on_chain_config::validator_info::ValidatorInfo {
+    api_types::on_chain_config::validator_info::ValidatorInfo {
+        account_address: convert_to_api_account_address(validator_info.account_address()),
+        consensus_voting_power: validator_info.consensus_voting_power(),
+        config: convert_to_api_validator_config(validator_info.config()),
+    }
+}
+
+/// Convert gravity-aptos ValidatorConfig to api-types ValidatorConfig
+pub fn convert_to_api_validator_config(
+    validator_config: &ValidatorConfig,
+) -> api_types::on_chain_config::validator_config::ValidatorConfig {
+    api_types::on_chain_config::validator_config::ValidatorConfig {
+        consensus_public_key: validator_config.consensus_public_key.to_bytes().to_vec(),
+        validator_network_addresses: validator_config.validator_network_addresses.clone(),
+        fullnode_network_addresses: validator_config.fullnode_network_addresses.clone(),
+        validator_index: validator_config.validator_index,
+    }
+}
+
+/// Convert gravity-aptos AccountAddress to api-types AccountAddress
+pub fn convert_to_api_account_address(
+    gravity_address: &AccountAddress,
+) -> api_types::u256_define::AccountAddress {
+    api_types::u256_define::AccountAddress::new(gravity_address.into())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::network_address::NetworkAddress;
+
+    #[test]
+    fn test_convert_validator_info_roundtrip() {
+        // Create a gravity-aptos ValidatorInfo
+        let validator_info = ValidatorInfo::new(
+            AccountAddress::from_hex_literal(
+                "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+            )
+            .unwrap(),
+            1000,
+            ValidatorConfig::new(
+                bls12381::PublicKey::try_from(&[42u8; 48][..]).unwrap(),
+                bcs::to_bytes(&vec![NetworkAddress::mock()]).unwrap(),
+                bcs::to_bytes(&vec![NetworkAddress::mock()]).unwrap(),
+                42,
+            ),
+        );
+
+        // Convert to api-types
+        let api_validator_info = convert_to_api_validator_info(&validator_info);
+
+        // Convert back to gravity-aptos
+        let converted_back = convert_validator_info(&api_validator_info).unwrap();
+
+        // Should be equal
+        assert_eq!(validator_info, converted_back);
+    }
+
+    #[test]
+    fn test_convert_validator_config() {
+        let validator_config = ValidatorConfig::new(
+            bls12381::PublicKey::try_from(&[42u8; 48][..]).unwrap(),
+            vec![1, 2, 3, 4],
+            vec![5, 6, 7, 8],
+            42,
+        );
+
+        let api_config = convert_to_api_validator_config(&validator_config);
+        let converted_back = convert_validator_config(&api_config).unwrap();
+
+        assert_eq!(validator_config, converted_back);
+    }
+
+    #[test]
+    fn test_convert_account_address() {
+        let gravity_address = AccountAddress::from_hex_literal(
+            "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+        )
+        .unwrap();
+
+        let api_address = convert_to_api_account_address(&gravity_address);
+        let converted_back = convert_account_address(&api_address).unwrap();
+
+        assert_eq!(gravity_address, converted_back);
+    }
+}

--- a/types/src/idl/error.rs
+++ b/types/src/idl/error.rs
@@ -1,0 +1,37 @@
+// Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Error types for IDL operations
+
+use thiserror::Error;
+
+/// Error types for ValidatorInfo IDL operations
+#[derive(Debug, Error)]
+pub enum ValidatorInfoIdlError {
+    #[error("JSON deserialization error: {0}")]
+    JsonDeserializationError(String),
+    #[error("Account address parsing error: {0}")]
+    AccountAddressError(String),
+    #[error("Consensus public key parsing error: {0}")]
+    ConsensusPublicKeyError(String),
+    #[error("Network addresses BCS deserialization error: {0}")]
+    NetworkAddressesError(String),
+    #[error("Base64 decoding error: {0}")]
+    Base64Error(String),
+    #[error("Hex decoding error: {0}")]
+    HexError(String),
+}
+
+/// Error types for general IDL operations
+#[derive(Debug, Error)]
+pub enum IdlError {
+    #[error("ValidatorInfo IDL error: {0}")]
+    ValidatorInfo(#[from] ValidatorInfoIdlError),
+    #[error("JSON serialization error: {0}")]
+    JsonSerializationError(String),
+    #[error("JSON deserialization error: {0}")]
+    JsonDeserializationError(String),
+    #[error("Unsupported type: {0}")]
+    UnsupportedType(String),
+} 

--- a/types/src/idl/mod.rs
+++ b/types/src/idl/mod.rs
@@ -1,0 +1,29 @@
+// Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! JSON IDL (Interface Definition Language) tools for cross-language serialization
+//! 
+//! This module provides tools for serializing and deserializing Aptos types to/from JSON
+//! format that can be used across different programming languages and libraries.
+//! 
+//! ## Usage Example
+//! 
+//! ```rust
+//! use aptos_types::idl::{ValidatorInfoIdl, ValidatorInfoIdlError};
+//! 
+//! // Serialize ValidatorInfo to JSON
+//! let validator_info = /* your ValidatorInfo instance */;
+//! let json_string = validator_info.to_json_idl()?;
+//! 
+//! // Deserialize from JSON
+//! let deserialized = ValidatorInfo::from_json_idl(&json_string)?;
+//! ```
+
+pub mod validator_info;
+pub mod error;
+pub mod api_types_converter;
+
+pub use validator_info::*;
+pub use error::*;
+pub use api_types_converter::*; 

--- a/types/src/idl/validator_info.rs
+++ b/types/src/idl/validator_info.rs
@@ -1,0 +1,211 @@
+// Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! ValidatorInfo IDL implementation for cross-language serialization
+
+use crate::{
+    account_address::AccountAddress,
+    validator_config::ValidatorConfig,
+    validator_info::ValidatorInfo,
+};
+use aptos_crypto::bls12381;
+use serde::{Deserialize, Serialize};
+use std::convert::TryFrom;
+
+use super::error::ValidatorInfoIdlError;
+
+/// JSON IDL representation of ValidatorInfo for cross-language serialization
+/// 
+/// This struct represents ValidatorInfo in a JSON-friendly format that can be
+/// easily serialized and deserialized across different programming languages.
+/// 
+/// ## JSON Format
+/// ```json
+/// {
+///   "account_address": "0x1234567890abcdef...",
+///   "consensus_voting_power": 1000,
+///   "config": {
+///     "consensus_public_key": "0xabcdef1234567890...",
+///     "validator_network_addresses": "base64_encoded_bcs_bytes",
+///     "fullnode_network_addresses": "base64_encoded_bcs_bytes",
+///     "validator_index": 42
+///   }
+/// }
+/// ```
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct ValidatorInfoIdl {
+    /// Account address in hex format (0x-prefixed)
+    pub account_address: String,
+    /// Voting power for consensus
+    pub consensus_voting_power: u64,
+    /// Validator configuration
+    pub config: ValidatorConfigIdl,
+}
+
+/// JSON IDL representation of ValidatorConfig for cross-language serialization
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct ValidatorConfigIdl {
+    /// Consensus public key in hex format
+    pub consensus_public_key: String,
+    /// Validator network addresses as base64-encoded BCS bytes
+    pub validator_network_addresses: String,
+    /// Fullnode network addresses as base64-encoded BCS bytes
+    pub fullnode_network_addresses: String,
+    /// Validator index in the validator set
+    pub validator_index: u64,
+}
+
+impl From<&ValidatorInfo> for ValidatorInfoIdl {
+    fn from(validator_info: &ValidatorInfo) -> Self {
+        ValidatorInfoIdl {
+            account_address: validator_info.account_address.to_hex(),
+            consensus_voting_power: validator_info.consensus_voting_power(),
+            config: ValidatorConfigIdl::from(validator_info.config()),
+        }
+    }
+}
+
+impl From<&ValidatorConfig> for ValidatorConfigIdl {
+    fn from(config: &ValidatorConfig) -> Self {
+        ValidatorConfigIdl {
+            consensus_public_key: hex::encode(config.consensus_public_key.to_bytes()),
+            validator_network_addresses: base64::encode(&config.validator_network_addresses),
+            fullnode_network_addresses: base64::encode(&config.fullnode_network_addresses),
+            validator_index: config.validator_index,
+        }
+    }
+}
+
+impl TryFrom<ValidatorInfoIdl> for ValidatorInfo {
+    type Error = ValidatorInfoIdlError;
+
+    fn try_from(idl: ValidatorInfoIdl) -> Result<Self, Self::Error> {
+        let account_address = AccountAddress::from_hex_literal(&idl.account_address)
+            .map_err(|e| ValidatorInfoIdlError::AccountAddressError(e.to_string()))?;
+        
+        let config = idl.config.try_into()?;
+
+        Ok(ValidatorInfo::new(
+            account_address,
+            idl.consensus_voting_power,
+            config,
+        ))
+    }
+}
+
+impl TryFrom<ValidatorConfigIdl> for ValidatorConfig {
+    type Error = ValidatorInfoIdlError;
+
+    fn try_from(idl: ValidatorConfigIdl) -> Result<Self, Self::Error> {
+        let consensus_public_key_bytes = hex::decode(&idl.consensus_public_key)
+            .map_err(|e| ValidatorInfoIdlError::HexError(e.to_string()))?;
+        
+        let consensus_public_key = bls12381::PublicKey::try_from(consensus_public_key_bytes.as_slice())
+            .map_err(|e| ValidatorInfoIdlError::ConsensusPublicKeyError(e.to_string()))?;
+
+        let validator_network_addresses = base64::decode(&idl.validator_network_addresses)
+            .map_err(|e| ValidatorInfoIdlError::Base64Error(e.to_string()))?;
+
+        let fullnode_network_addresses = base64::decode(&idl.fullnode_network_addresses)
+            .map_err(|e| ValidatorInfoIdlError::Base64Error(e.to_string()))?;
+
+        Ok(ValidatorConfig::new(
+            consensus_public_key,
+            validator_network_addresses,
+            fullnode_network_addresses,
+            idl.validator_index,
+        ))
+    }
+}
+
+// Extension trait for ValidatorInfo to add IDL functionality
+pub trait ValidatorInfoIdlExt {
+    /// Serialize ValidatorInfo to JSON string for IDL purposes
+    fn to_json_idl(&self) -> Result<String, serde_json::Error>;
+    
+    /// Deserialize ValidatorInfo from JSON string for IDL purposes
+    fn from_json_idl(json: &str) -> Result<Self, ValidatorInfoIdlError> where Self: Sized;
+}
+
+impl ValidatorInfoIdlExt for ValidatorInfo {
+    fn to_json_idl(&self) -> Result<String, serde_json::Error> {
+        let idl_representation = ValidatorInfoIdl::from(self);
+        serde_json::to_string_pretty(&idl_representation)
+    }
+
+    fn from_json_idl(json: &str) -> Result<Self, ValidatorInfoIdlError> {
+        let idl_representation: ValidatorInfoIdl = serde_json::from_str(json)
+            .map_err(|e| ValidatorInfoIdlError::JsonDeserializationError(e.to_string()))?;
+        idl_representation.try_into()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::network_address::NetworkAddress;
+
+    #[test]
+    fn test_validator_info_idl_roundtrip() {
+        let validator_info = ValidatorInfo::new(
+            AccountAddress::from_hex_literal("0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef").unwrap(),
+            1000,
+            ValidatorConfig::new(
+                bls12381::PublicKey::try_from(&[42u8; 48][..]).unwrap(),
+                bcs::to_bytes(&vec![NetworkAddress::mock()]).unwrap(),
+                bcs::to_bytes(&vec![NetworkAddress::mock()]).unwrap(),
+                42,
+            ),
+        );
+
+        // Test serialization to JSON IDL
+        let json_idl = validator_info.to_json_idl().unwrap();
+        println!("JSON IDL: {}", json_idl);
+
+        // Test deserialization from JSON IDL
+        let deserialized = ValidatorInfo::from_json_idl(&json_idl).unwrap();
+        assert_eq!(validator_info, deserialized);
+    }
+
+    #[test]
+    fn test_validator_info_idl_format() {
+        let validator_info = ValidatorInfo::new(
+            AccountAddress::from_hex_literal("0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef").unwrap(),
+            1000,
+            ValidatorConfig::new(
+                bls12381::PublicKey::try_from(&[42u8; 48][..]).unwrap(),
+                bcs::to_bytes(&vec![NetworkAddress::mock()]).unwrap(),
+                bcs::to_bytes(&vec![NetworkAddress::mock()]).unwrap(),
+                42,
+            ),
+        );
+
+        let json_idl = validator_info.to_json_idl().unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&json_idl).unwrap();
+        
+        // Verify the structure
+        assert!(parsed.get("account_address").is_some());
+        assert!(parsed.get("consensus_voting_power").is_some());
+        assert!(parsed.get("config").is_some());
+        
+        let config = parsed.get("config").unwrap();
+        assert!(config.get("consensus_public_key").is_some());
+        assert!(config.get("validator_network_addresses").is_some());
+        assert!(config.get("fullnode_network_addresses").is_some());
+        assert!(config.get("validator_index").is_some());
+    }
+
+    #[test]
+    fn test_validator_info_idl_error_handling() {
+        // Test invalid JSON
+        let invalid_json = "{ invalid json }";
+        let result = ValidatorInfo::from_json_idl(invalid_json);
+        assert!(result.is_err());
+
+        // Test missing required fields
+        let incomplete_json = r#"{"account_address": "0x123"}"#;
+        let result = ValidatorInfo::from_json_idl(incomplete_json);
+        assert!(result.is_err());
+    }
+} 

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -57,6 +57,9 @@ pub mod vm_status;
 pub mod waypoint;
 pub mod write_set;
 
+// IDL (Interface Definition Language) modules for cross-language serialization
+pub mod idl;
+
 pub use account_address::AccountAddress as PeerId;
 pub use utility_coin::*;
 

--- a/types/src/on_chain_config/validator_set.rs
+++ b/types/src/on_chain_config/validator_set.rs
@@ -2,7 +2,7 @@
 // Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{on_chain_config::OnChainConfig, validator_info::ValidatorInfo};
+use crate::{idl::construct_and_convert_validator_set, on_chain_config::OnChainConfig, validator_info::ValidatorInfo};
 use move_core_types::account_address::AccountAddress;
 #[cfg(any(test, feature = "fuzzing"))]
 use proptest_derive::Arbitrary;
@@ -13,6 +13,7 @@ use std::{
     vec,
     vec::IntoIter,
 };
+use anyhow::{format_err, Result};
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
@@ -98,6 +99,10 @@ impl OnChainConfig for ValidatorSet {
     // validator_set_address
     const MODULE_IDENTIFIER: &'static str = "stake";
     const TYPE_IDENTIFIER: &'static str = "ValidatorSet";
+
+    fn deserialize_into_config(bytes: &[u8]) -> Result<Self> {
+        Ok(construct_and_convert_validator_set(bytes)?)
+    }
 }
 
 impl IntoIterator for ValidatorSet {


### PR DESCRIPTION
To avoid the cycle dependency problem for execution layer and consensus layer. we add one trivial type ValidatorSet in onchain_config. So user can directly use the package api-types to include the types.
Then we add one convert function which transforms this trivial type into Aptos's type.