### PR TITLE
feat: update upstream roles for `NetworkId::Vfn`

### DIFF
--- a/config/src/network_id.rs
+++ b/config/src/network_id.rs
@@ -180,7 +180,7 @@ impl NetworkId {
             ],
             NetworkId::Vfn => match role {
                 RoleType::Validator => &[],
-                RoleType::FullNode => &[PeerRole::Validator],
+                RoleType::FullNode => &[PeerRole::Validator, PeerRole::ValidatorFullNode],
             },
         }
     }


### PR DESCRIPTION
Update upstream roles for `NetworkId::Vfn` to support VFN connecting to the vfn network provided by validator through onchain discovery method.