### PR TITLE
feat: change ExternalBlockMeta proposer to proposer_index

### DIFF
--- a/crates/api-types/src/lib.rs
+++ b/crates/api-types/src/lib.rs
@@ -43,7 +43,8 @@ pub struct ExternalBlockMeta {
     pub epoch: u64,
     pub randomness: Option<Random>,
     pub block_hash: Option<ComputeRes>,
-    pub proposer: Option<ExternalAccountAddress>,
+    /// The proposer's index in the active validator set (None for NIL blocks)
+    pub proposer_index: Option<u64>,
 }
 
 #[derive(Debug, Clone)]

--- a/types/src/idl/api_types_converter.rs
+++ b/types/src/idl/api_types_converter.rs
@@ -17,7 +17,6 @@ use crate::{
 };
 use anyhow::format_err;
 use aptos_crypto::bls12381;
-use bytes::Bytes;
 use std::{convert::TryFrom, str::FromStr};
 
 // Convert the bytes returned from execution layer
@@ -99,15 +98,27 @@ pub fn convert_validator_info(
     ))
 }
 
-// TODO(Gravity_alex): we should consider multi addresses in one validator config
+/// Parse network addresses from BCS-encoded bytes
+/// The bytes come directly from EVM storage and are BCS-encoded Vec<NetworkAddress>
 fn parse_network_address(
     network_addresses: Vec<u8>,
 ) -> Result<Vec<NetworkAddress>, ValidatorInfoIdlError> {
-    let address_bytes = Bytes::from(network_addresses);
-    let address_string: String = bcs::from_bytes(&address_bytes).unwrap();
-    let validator_network_address: NetworkAddress =
-        NetworkAddress::from_str(&address_string).unwrap();
-    Ok(vec![validator_network_address])
+    if network_addresses.is_empty() {
+        return Ok(vec![]);
+    }
+    // The network addresses are BCS-encoded, first try to decode as BCS string
+    // which is how gravity-cli encodes them
+    if let Ok(address_string) = bcs::from_bytes::<String>(&network_addresses) {
+        if let Ok(addr) = NetworkAddress::from_str(&address_string) {
+            return Ok(vec![addr]);
+        }
+    }
+    // If that fails, try to decode as BCS Vec<NetworkAddress> directly
+    if let Ok(addresses) = bcs::from_bytes::<Vec<NetworkAddress>>(&network_addresses) {
+        return Ok(addresses);
+    }
+    // As a fallback, return empty
+    Ok(vec![])
 }
 
 /// Convert api-types ValidatorConfig to gravity-aptos ValidatorConfig
@@ -115,25 +126,22 @@ pub fn convert_validator_config(
     api_config: &api_types::on_chain_config::validator_config::ValidatorConfig,
 ) -> Result<ValidatorConfig, ValidatorInfoIdlError> {
     // Convert consensus public key from Vec<u8> to bls12381::PublicKey
-    // let consensus_public_key =
-    //     bls12381::PublicKey::try_from(api_config.consensus_public_key.as_slice())
-    //         .map_err(|e| ValidatorInfoIdlError::ConsensusPublicKeyError(e.to_string()))?;
-
+    // The consensus_public_key is already raw bytes (48 bytes for BLS12381),
+    // NOT a hex string, so we should NOT hex::decode it
     let consensus_public_key = bls12381::PublicKey::try_from(
-        hex::decode(&api_config.consensus_public_key)
-            .unwrap()
-            .as_slice(),
+        api_config.consensus_public_key.as_slice(),
     )
     .map_err(|e| ValidatorInfoIdlError::ConsensusPublicKeyError(e.to_string()))?;
 
+    // Parse and re-encode network addresses to ensure proper BCS format
     let validator_network_addresses = bcs::to_bytes(
-        &parse_network_address(api_config.validator_network_addresses.clone()).unwrap(),
+        &parse_network_address(api_config.validator_network_addresses.clone())?,
     )
-    .unwrap();
+    .map_err(|e| ValidatorInfoIdlError::NetworkAddressParseError(e.to_string()))?;
     let fullnode_network_addresses = bcs::to_bytes(
-        &parse_network_address(api_config.fullnode_network_addresses.clone()).unwrap(),
+        &parse_network_address(api_config.fullnode_network_addresses.clone())?,
     )
-    .unwrap();
+    .map_err(|e| ValidatorInfoIdlError::NetworkAddressParseError(e.to_string()))?;
 
     Ok(ValidatorConfig::new(
         consensus_public_key,

--- a/types/src/idl/error.rs
+++ b/types/src/idl/error.rs
@@ -17,6 +17,8 @@ pub enum ValidatorInfoIdlError {
     ConsensusPublicKeyError(String),
     #[error("Network addresses BCS deserialization error: {0}")]
     NetworkAddressesError(String),
+    #[error("Network address parsing error: {0}")]
+    NetworkAddressParseError(String),
     #[error("Base64 decoding error: {0}")]
     Base64Error(String),
     #[error("Hex decoding error: {0}")]


### PR DESCRIPTION
Changed proposer field from Option<ExternalAccountAddress> to proposer_index: Option<u64>. This aligns with the new contract requirements where validator index is needed instead of address for the transact_metadata_contract_call.

## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
