### PR TITLE
refactor(jwk-manager): implement incremental update model for gravity sources

### DIFF
--- a/crates/aptos-jwk-consensus/src/jwk_manager/mod.rs
+++ b/crates/aptos-jwk-consensus/src/jwk_manager/mod.rs
@@ -240,49 +240,118 @@ impl JWKManager {
         Ok(())
     }
 
+    /// Extract (sourceType, sourceId) from gravity:// issuer URI
+    /// Handles both formats:
+    /// - Full URI: "gravity://0/1/events?portal=..."
+    /// - Simplified: "gravity://0/1"
+    fn extract_source_key(issuer: &Issuer) -> Option<(u32, u64)> {
+        let issuer_str = String::from_utf8(issuer.clone()).ok()?;
+        if !issuer_str.starts_with("gravity://") {
+            return None;
+        }
+        let rest = &issuer_str[10..]; // skip "gravity://"
+        let parts: Vec<&str> = rest.split('/').collect();
+        if parts.len() >= 2 {
+            let source_type: u32 = parts[0].parse().ok()?;
+            // Handle case where source_id might have query params attached
+            let source_id: u64 = parts[1].split('?').next()?.parse().ok()?;
+            Some((source_type, source_id))
+        } else {
+            None
+        }
+    }
+
     /// Invoked on start, or on on-chain JWK updated event.
+    /// NOTE(Gravity): Modified for incremental update model - only updates entries
+    /// that are present in on_chain_state, does not delete missing entries.
     pub fn reset_with_on_chain_state(&mut self, on_chain_state: AllProvidersJWKs) -> Result<()> {
         info!(
             epoch = self.epoch_state.epoch,
             "reset_with_on_chain_state starting."
         );
-        let onchain_issuer_set: HashSet<Issuer> = on_chain_state
-            .entries
-            .iter()
-            .map(|entry| entry.issuer.clone())
-            .collect();
-        let local_issuer_set: HashSet<Issuer> = self.states_by_issuer.keys().cloned().collect();
 
-        for issuer in local_issuer_set.difference(&onchain_issuer_set) {
-            info!(
-                epoch = self.epoch_state.epoch,
-                op = "delete",
-                issuer = issuer.clone(),
-                "reset_with_on_chain_state"
-            );
-        }
+        // NOTE(Gravity): Commented out delete logic for incremental update model.
+        // The new design from gravity-reth sends only entries that had DataRecorded events,
+        // not the complete set. Missing entries means "no update", not "deleted".
+        // Keeping this commented for easier upstream merge comparison.
+        //
+        // let onchain_issuer_set: HashSet<Issuer> = on_chain_state
+        //     .entries
+        //     .iter()
+        //     .map(|entry| entry.issuer.clone())
+        //     .collect();
+        // let local_issuer_set: HashSet<Issuer> = self.states_by_issuer.keys().cloned().collect();
+        //
+        // for issuer in local_issuer_set.difference(&onchain_issuer_set) {
+        //     info!(
+        //         epoch = self.epoch_state.epoch,
+        //         op = "delete",
+        //         issuer = issuer.clone(),
+        //         "reset_with_on_chain_state"
+        //     );
+        // }
+        //
+        // self.states_by_issuer
+        //     .retain(|issuer, _| onchain_issuer_set.contains(issuer));
 
-        self.states_by_issuer
-            .retain(|issuer, _| onchain_issuer_set.contains(issuer));
         for on_chain_provider_jwks in on_chain_state.entries {
-            let issuer = on_chain_provider_jwks.issuer.clone();
+            let incoming_issuer = on_chain_provider_jwks.issuer.clone();
+
+            // Match by source key to handle issuer format differences
+            // Aptos uses: gravity://0/1/events?portal=...
+            // Reth uses:  gravity://0/1
+            let source_key = Self::extract_source_key(&incoming_issuer);
+            let matching_local_issuer = source_key.and_then(|key| {
+                self.states_by_issuer
+                    .keys()
+                    .find(|local| Self::extract_source_key(local) == Some(key))
+                    .cloned()
+            });
+
+            // Use local format if match found, otherwise use incoming
+            let target_issuer = match &matching_local_issuer {
+                Some(local) => local.clone(),
+                None => {
+                    // Log error if this is a gravity:// source with no local match
+                    if source_key.is_some() {
+                        error!(
+                            epoch = self.epoch_state.epoch,
+                            incoming_issuer = String::from_utf8_lossy(&incoming_issuer).to_string(),
+                            source_key = ?source_key,
+                            "No matching local issuer found for gravity:// source"
+                        );
+                    }
+                    incoming_issuer.clone()
+                }
+            };
+
             let locally_cached = self
                 .states_by_issuer
-                .get(&on_chain_provider_jwks.issuer)
+                .get(&target_issuer)
                 .and_then(|s| s.on_chain.as_ref());
-            if locally_cached == Some(&on_chain_provider_jwks) {
-                // The on-chain update did not touch this provider.
-                // The corresponding local state does not have to be reset.
+
+            // Compare by version for gravity:// sources, by content otherwise
+            let is_same = match (locally_cached, source_key) {
+                (Some(cached), Some(_)) => cached.version >= on_chain_provider_jwks.version,
+                (Some(cached), None) => cached == &on_chain_provider_jwks,
+                (None, _) => false,
+            };
+
+            if is_same {
                 info!(
                     epoch = self.epoch_state.epoch,
                     op = "no-op",
-                    issuer = issuer,
+                    issuer = String::from_utf8_lossy(&target_issuer).to_string(),
                     "reset_with_on_chain_state"
                 );
             } else {
+                // Update with local issuer format preserved
+                let mut updated_jwks = on_chain_provider_jwks.clone();
+                updated_jwks.issuer = target_issuer.clone();
+
                 let old_value = self.states_by_issuer.insert(
-                    on_chain_provider_jwks.issuer.clone(),
-                    PerProviderState::new(on_chain_provider_jwks),
+                    target_issuer.clone(),
+                    PerProviderState::new(updated_jwks),
                 );
                 let op = if old_value.is_some() {
                     "update"
@@ -292,7 +361,7 @@ impl JWKManager {
                 info!(
                     epoch = self.epoch_state.epoch,
                     op = op,
-                    issuer = issuer,
+                    issuer = String::from_utf8_lossy(&target_issuer).to_string(),
                     "reset_with_on_chain_state"
                 );
             }

--- a/crates/aptos-jwk-consensus/src/jwk_manager/tests.rs
+++ b/crates/aptos-jwk-consensus/src/jwk_manager/tests.rs
@@ -434,7 +434,8 @@ async fn test_jwk_manager_state_transition() {
         .collect::<HashSet<_>>();
     assert_eq!(expected_vtxn_hashes, actual_vtxn_hashes);
 
-    // At any time, JWKConsensusManager should fully follow on-chain update notification and re-initialize.
+    // NOTE(Gravity): At any time, JWKConsensusManager should follow on-chain update notification.
+    // With incremental update model, missing entries are NOT deleted.
     let second_on_chain_state = AllProvidersJWKs {
         entries: vec![on_chain_state_alice_v111.clone()],
     };
@@ -442,8 +443,10 @@ async fn test_jwk_manager_state_transition() {
     assert!(jwk_manager
         .reset_with_on_chain_state(second_on_chain_state)
         .is_ok());
-    expected_states.remove(&issuer_bob);
-    expected_states.remove(&issuer_carl);
+    // NOTE(Gravity): With incremental model, Bob and Carl remain (they just weren't updated).
+    // Commented out for easier upstream merge comparison.
+    // expected_states.remove(&issuer_bob);
+    // expected_states.remove(&issuer_carl);
     assert_eq!(expected_states, jwk_manager.states_by_issuer);
 }
 


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

Remove deletion logic for missing entries; gravity-reth only sends updates for entries with DataRecorded events, not complete state. Add source key matching to handle format differences between Aptos and Reth issuers, and use version comparison for gravity:// sources.

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
