### PR TITLE
enhance: skip self_author in to_bytes_by_protocol

### DIFF
--- a/crates/reliable-broadcast/src/lib.rs
+++ b/crates/reliable-broadcast/src/lib.rs
@@ -124,7 +124,11 @@ where
         async move {
             let message: Req = message.into();
 
-            let peers = receivers.clone();
+            let peers = receivers
+                .iter()
+                .filter(|&author| author != &self_author)
+                .cloned()
+                .collect();
             let sender = network_sender.clone();
             let message_clone = message.clone();
             let protocols = Arc::new(


### PR DESCRIPTION
Skip self_author in to_bytes_by_protocol to avoid false positive logs for self-node: "Unavailable peers (without a common network protocol)"