### PR TITLE
fix: handle GTxnBytes payloads gracefully to prevent panic DoS

### DIFF
--- a/api/src/transactions.rs
+++ b/api/src/transactions.rs
@@ -1107,7 +1107,13 @@ impl TransactionsApi {
                         ))
                     },
 
-                    TransactionPayload::GTxnBytes(_) => todo!(),
+                    TransactionPayload::GTxnBytes(_) => {
+                        return Err(SubmitTransactionError::bad_request_with_code(
+                            "GTxnBytes payload is unsupported",
+                            AptosErrorCode::InvalidInput,
+                            ledger_info,
+                        ))
+                    },
                 }
                 // TODO: Verify script args?
 
@@ -1425,7 +1431,7 @@ impl TransactionsApi {
                     "Multisig::unknown".to_string()
                 }
             },
-            TransactionPayload::GTxnBytes(_) => todo!(),
+            TransactionPayload::GTxnBytes(_) => "GTxnBytes::unknown".to_string(),
         };
         self.context
             .simulate_txn_stats()

--- a/aptos-move/aptos-vm/src/aptos_vm.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm.rs
@@ -861,10 +861,12 @@ impl AptosVM {
             let module_id = traversal_context
                 .referenced_module_ids
                 .alloc(entry_fn.module().clone());
-            check_dependencies_and_charge_gas(module_storage, gas_meter, traversal_context, [(
-                module_id.address(),
-                module_id.name(),
-            )])?;
+            check_dependencies_and_charge_gas(
+                module_storage,
+                gas_meter,
+                traversal_context,
+                [(module_id.address(), module_id.name())],
+            )?;
         }
 
         if self.gas_feature_version() >= RELEASE_V1_27 {
@@ -1978,7 +1980,9 @@ impl AptosVM {
             TransactionPayload::ModuleBundle(_) => {
                 unwrap_or_discard!(Err(deprecated_module_bundle!()))
             },
-            TransactionPayload::GTxnBytes(_) => todo!(),
+            TransactionPayload::GTxnBytes(_) => {
+                unwrap_or_discard!(Err(deprecated_module_bundle!()))
+            },
         };
         drop(payload_timer);
 
@@ -2589,7 +2593,7 @@ impl AptosVM {
 
             // Deprecated.
             TransactionPayload::ModuleBundle(_) => Err(deprecated_module_bundle!()),
-            TransactionPayload::GTxnBytes(_) => todo!(),
+            TransactionPayload::GTxnBytes(_) => Err(deprecated_module_bundle!()),
         }
     }
 


### PR DESCRIPTION
Replace todo!() with proper error handling for TransactionPayload::GTxnBytes arms to prevent remote attackers from crashing nodes by submitting crafted GTxnBytes payloads.