### PR TITLE
fix: skip empty JWK observations when relayer reports no update

### DIFF
--- a/crates/aptos-jwk-consensus/src/jwk_observer.rs
+++ b/crates/aptos-jwk-consensus/src/jwk_observer.rs
@@ -130,6 +130,9 @@ async fn fetch_jwks_with_relayer(issuer: &str) -> Result<(Vec<JWK>, Option<u128>
         .map_err(|e| anyhow!("fetch_jwks failed with relayer request: {:?}", e))?;
     let PollResult { jwk_structs, max_block_number, nonce, updated } = poll_result;
     debug!(issuer = issuer, max_block_number = max_block_number, nonce = ?nonce, updated = updated, "fetch_jwks_with_relayer");
+    if !updated {
+        return Err(anyhow!("No new data from relayer for issuer: {}", issuer));
+    }
     let jwks = jwk_structs
         .into_iter()
         .map(|jwk| {


### PR DESCRIPTION
When the relayer's PollResult has updated=false (no new events found), the observer was still forwarding empty JWK data to JWKManager. This caused process_new_observation to treat empty observations as new state, triggering consensus on empty ProviderJWKs.

With 10 validators all seeing the same empty state during startup, they would reach quorum on empty JWKs, causing 'No JWKs found for issuer' errors in the execution layer.

Fix: check the existing updated field in PollResult and return early when no new data is available.

## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
