### PR TITLE
fix(inspection-service): handle None aptos_data_client in /peer_information endpoint

### DIFF
--- a/crates/aptos-inspection-service/src/server/mod.rs
+++ b/crates/aptos-inspection-service/src/server/mod.rs
@@ -140,11 +140,18 @@ async fn serve_requests(
         PEER_INFORMATION_PATH => {
             // /peer_information
             // Exposes the peer information
-            peer_information::handle_peer_information_request(
-                &node_config,
-                aptos_data_client.unwrap(),
-                peers_and_metadata,
-            )
+            match aptos_data_client {
+                Some(client) => peer_information::handle_peer_information_request(
+                    &node_config,
+                    client,
+                    peers_and_metadata,
+                ),
+                None => (
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    Body::from("Peer information is not available (no data client configured)"),
+                    CONTENT_TYPE_TEXT.into(),
+                ),
+            }
         },
         SYSTEM_INFORMATION_PATH => {
             // /system_information


### PR DESCRIPTION
When aptos_data_client is None (e.g. in gravity-sdk where it's not provided), requesting /peer_information would panic on unwrap(). Return 503 instead.