### PR TITLE
fix: security audit fixes

### DIFF
--- a/aptos-move/aptos-vm/src/transaction_metadata.rs
+++ b/aptos-move/aptos-vm/src/transaction_metadata.rs
@@ -66,7 +66,7 @@ impl TransactionMetadata {
                 // Deprecated. Return an empty vec because we cannot do anything
                 // else here, only `unreachable!` otherwise.
                 TransactionPayload::ModuleBundle(_) => vec![],
-                TransactionPayload::GTxnBytes(_) => todo!(),
+                TransactionPayload::GTxnBytes(_) => vec![],
             },
             script_size: match txn.payload() {
                 TransactionPayload::Script(s) => (s.code().len() as u64).into(),

--- a/crates/api-types/src/lib.rs
+++ b/crates/api-types/src/lib.rs
@@ -145,11 +145,7 @@ impl VerifiedTxn {
     pub fn committed_hash(&self) -> [u8; 32] {
         self.committed_hash
             .get_or_init(|| {
-                let hash_bytes = match GLOBAL_CRYPTO_TXN_HASHER.get() {
-                    Some(hasher) => hasher(self.bytes()),
-                    None => simple_hash::hash_to_fixed_array(self.bytes()),
-                };
-                u256_define::TxnHash::new(hash_bytes)
+                u256_define::TxnHash::new(GLOBAL_CRYPTO_TXN_HASHER.get().unwrap()(self.bytes()))
             })
             .bytes()
     }

--- a/crates/api-types/src/lib.rs
+++ b/crates/api-types/src/lib.rs
@@ -86,12 +86,12 @@ pub struct ExecutionArgs {
 
 #[derive(Clone, Deserialize, Serialize)]
 pub struct VerifiedTxn {
-    pub bytes: Vec<u8>,
-    pub sender: ExternalAccountAddress,
-    pub sequence_number: u64,
-    pub chain_id: ExternalChainId,
+    bytes: Vec<u8>,
+    sender: ExternalAccountAddress,
+    sequence_number: u64,
+    chain_id: ExternalChainId,
     #[serde(skip)]
-    pub committed_hash: OnceCell<TxnHash>,
+    committed_hash: OnceCell<TxnHash>,
 }
 
 // implment the Debug for VerifiedTxn
@@ -122,9 +122,8 @@ impl VerifiedTxn {
         sender: ExternalAccountAddress,
         sequence_number: u64,
         chain_id: ExternalChainId,
-        committed_hash: TxnHash,
     ) -> Self {
-        Self { bytes, sender, sequence_number, chain_id, committed_hash: committed_hash.into() }
+        Self { bytes, sender, sequence_number, chain_id, committed_hash: OnceCell::new() }
     }
 
     pub fn bytes(&self) -> &Vec<u8> {
@@ -139,10 +138,18 @@ impl VerifiedTxn {
         self.sequence_number
     }
 
+    pub fn chain_id(&self) -> &ExternalChainId {
+        &self.chain_id
+    }
+
     pub fn committed_hash(&self) -> [u8; 32] {
         self.committed_hash
             .get_or_init(|| {
-                u256_define::TxnHash::new(GLOBAL_CRYPTO_TXN_HASHER.get().unwrap()(self.bytes()))
+                let hash_bytes = match GLOBAL_CRYPTO_TXN_HASHER.get() {
+                    Some(hasher) => hasher(self.bytes()),
+                    None => simple_hash::hash_to_fixed_array(self.bytes()),
+                };
+                u256_define::TxnHash::new(hash_bytes)
             })
             .bytes()
     }

--- a/types/src/contract_event.rs
+++ b/types/src/contract_event.rs
@@ -552,8 +552,7 @@ impl TryFrom<&GravityEvent> for ContractEvent {
     }
 }
 
-impl From<GravityEvent> for ContractEvent {
-    fn from(event: GravityEvent) -> Self {
-        ContractEvent::try_from(&event).unwrap()
-    }
-}
+// NOTE: The infallible `From<GravityEvent>` impl was removed because it wraps
+// `TryFrom` with `.unwrap()`, which panics on malformed events (e.g. unknown JWK types).
+// Callers should use `ContractEvent::try_from(&event)` and handle errors explicitly.
+// See gravity-sdk `StateComputeResult::events()` for the primary call site.

--- a/types/src/idl/api_types_converter.rs
+++ b/types/src/idl/api_types_converter.rs
@@ -121,12 +121,14 @@ fn parse_network_address(
     if let Ok(addresses) = bcs::from_bytes::<Vec<NetworkAddress>>(&network_addresses) {
         return Ok(addresses);
     }
-    // Both deserialization strategies failed — log a warning
-    tracing::warn!(
-        bytes_len = network_addresses.len(),
-        "Failed to parse network addresses: neither BCS String nor BCS Vec<NetworkAddress> deserialization succeeded"
-    );
-    Ok(vec![])
+    // Both deserialization strategies failed — return error instead of empty vec
+    // to prevent phantom validators with unreachable addresses
+    Err(ValidatorInfoIdlError::NetworkAddressParseError(
+        format!(
+            "Failed to parse network addresses ({} bytes): neither BCS String nor BCS Vec<NetworkAddress> deserialization succeeded",
+            network_addresses.len()
+        )
+    ))
 }
 
 /// Convert api-types ValidatorConfig to gravity-aptos ValidatorConfig


### PR DESCRIPTION
- [#1](https://github.com/Lchangliang/gravity-aptos/issues/1): VerifiedTxn::committed_hash() fallback to SHA256 when GLOBAL_CRYPTO_TXN_HASHER uninitialized
- [#2](https://github.com/Lchangliang/gravity-aptos/issues/2): Make VerifiedTxn fields private, add chain_id() getter
- [#4](https://github.com/Lchangliang/gravity-aptos/issues/4): Remove committed_hash param from VerifiedTxn::new(), use lazy OnceCell
- [#13](https://github.com/Lchangliang/gravity-aptos/issues/13): Remove From<GravityEvent> impl that panics on fallible TryFrom
- [#14](https://github.com/Lchangliang/gravity-aptos/issues/14): Replace last todo!() for GTxnBytes in transaction_metadata.rs
- [#28](https://github.com/Lchangliang/gravity-aptos/issues/28): parse_network_address returns error instead of silent empty vec