### PR TITLE
fix(jwk-consensus): unblock consecutive observations within an epoch for gravity:// sources

### DIFF
--- a/crates/aptos-jwk-consensus/src/jwk_manager/mod.rs
+++ b/crates/aptos-jwk-consensus/src/jwk_manager/mod.rs
@@ -202,6 +202,29 @@ impl JWKManager {
                         on_chain_version = on_chain_version,
                         "Blockchain source needs update (version comparison)"
                     );
+                    // Fix B (diagnostic): warn if observed nonce is more than one
+                    // ahead of the on-chain version. The relayer always returns the
+                    // latest L1 event, so a gap > 1 means we will propose a
+                    // contiguous version (on_chain + 1) using the data of a
+                    // non-contiguous event — intermediate events between
+                    // on_chain_version+1 and nonce will be silently dropped.
+                    // This currently affects oracle/bridge sources when multiple
+                    // L1 events accumulate before the relayer catches up.
+                    // Long-term fix: queue events in the relayer and emit them
+                    // one at a time; tracked in companion issue.
+                    if let Some(gap) = nonce.checked_sub(on_chain_version + 1) {
+                        if gap > 0 {
+                            warn!(
+                                epoch = self.epoch_state.epoch,
+                                issuer = String::from_utf8(issuer.clone()).ok(),
+                                observed_nonce = nonce,
+                                on_chain_version = on_chain_version,
+                                missed_events = gap,
+                                "Observed nonce is more than one ahead of on-chain \
+                                 version; intermediate events may be dropped."
+                            );
+                        }
+                    }
                 }
                 should_update
             }
@@ -418,6 +441,46 @@ impl JWKManager {
                 let vtxn_guard =
                     self.vtxn_pool
                         .put(Topic::JWK_CONSENSUS(issuer.clone()), Arc::new(txn), None);
+
+                // Fix A: for oracle/bridge sources (gravity://), speculatively
+                // advance state.on_chain to the just-certified version.
+                //
+                // Why: the on-chain reset_with_on_chain_state path that would
+                // normally refresh state.on_chain fires off the
+                // ObservedJWKsUpdated event. For traditional OIDC JWK sources
+                // this event is emitted on every JWK update by the on-chain
+                // jwks module. For oracle/bridge sources the emission is not
+                // guaranteed (and empirically not happening on Gravity mainnet
+                // as of 2026-05). Without this speculative update,
+                // state.on_chain.version stays stale within an epoch, and the
+                // next observation for the same issuer is silently blocked
+                // (its proposed version collides with what is already on-chain),
+                // forcing the user-visible bridge message to wait until the
+                // next epoch boundary (worst case: epoch_interval, ~2h on
+                // mainnet).
+                //
+                // Why gated to gravity:// : for traditional JWK sources, a
+                // legitimate reset_with_on_chain_state can deliver a stale
+                // ProviderJWKs (e.g., a reconfig event that re-broadcasts the
+                // pre-update state). If we have already speculatively bumped
+                // state.on_chain to a newer post-QC version, the reset's
+                // version check would treat the stale snapshot as "different"
+                // and overwrite our valid Finished state. Restricting the
+                // speculative update to gravity:// avoids this regression for
+                // the JWK path while still fixing the bridge path.
+                //
+                // Safety: this is monotonic. The certified update's version is
+                // (state.on_chain_version() + 1) at the time the InProgress
+                // state was created, so it strictly exceeds the previous
+                // on_chain version. Guarded explicitly with the > check below
+                // for defense in depth.
+                let is_gravity_source = String::from_utf8(issuer.clone())
+                    .map(|s| s.starts_with("gravity://"))
+                    .unwrap_or(false);
+                if is_gravity_source && update.update.version > state.on_chain_version() {
+                    state.on_chain = Some(update.update.clone());
+                }
+
                 state.consensus_state = ConsensusState::Finished {
                     vtxn_guard,
                     my_proposal: my_proposal.clone(),

--- a/crates/aptos-jwk-consensus/src/jwk_manager/tests.rs
+++ b/crates/aptos-jwk-consensus/src/jwk_manager/tests.rs
@@ -334,6 +334,8 @@ async fn test_jwk_manager_state_transition() {
             my_proposal: expected_carl_state.consensus_state.my_proposal_cloned(),
             quorum_certified: qc_update_for_carl.clone(),
         };
+        // (Fix A speculative on_chain update is gated to gravity:// sources; Carl
+        //  uses an https:// issuer, so on_chain stays unchanged here.)
     }
     assert_eq!(expected_states, jwk_manager.states_by_issuer);
     let expected_vtxns = vec![ValidatorTransaction::ObservedJWKUpdate(
@@ -412,6 +414,8 @@ async fn test_jwk_manager_state_transition() {
             my_proposal: expected_alice_state.consensus_state.my_proposal_cloned(),
             quorum_certified: qc_update_for_alice.clone(),
         };
+        // (Fix A speculative on_chain update is gated to gravity:// sources; Alice
+        //  uses an https:// issuer, so on_chain stays unchanged here.)
     }
     assert_eq!(expected_states, jwk_manager.states_by_issuer);
     let expected_vtxn_hashes = vec![
@@ -486,4 +490,146 @@ impl TUpdateCertifier for DummyUpdateCertifier {
         let (abort_handle, _) = AbortHandle::new_pair();
         abort_handle
     }
+}
+
+/// Helper: build a JWKMoveStruct whose `variant.data` is exactly the 16-byte
+/// big-endian encoding of the given u128 nonce. This is the shape that
+/// `PerProviderState::convert_oracle_nonce` expects for oracle/bridge sources.
+fn oracle_jwk_with_nonce(nonce: u128) -> aptos_types::jwks::jwk::JWKMoveStruct {
+    use aptos_types::{jwks::jwk::JWKMoveStruct, move_any::Any};
+    JWKMoveStruct {
+        variant: Any {
+            type_name: "oracle::Nonce".to_string(),
+            data: nonce.to_be_bytes().to_vec(),
+        },
+    }
+}
+
+/// Regression test for the cross-chain "stuck within epoch" bug.
+///
+/// Repro: a validator certifies a JWK update for version V via
+/// `process_quorum_certified_update`. Then a new observation arrives with
+/// nonce V+1 (next bridge message). Before Fix A, `state.on_chain` would
+/// stay at the pre-cert value until the next epoch boundary, so the new
+/// observation's proposed version would collide with the just-committed
+/// version and silently fail to form a quorum cert. With Fix A, the local
+/// `state.on_chain` is advanced speculatively right after pool.put, so the
+/// next observation immediately starts a new InProgress cert cycle.
+#[tokio::test]
+async fn test_consecutive_observations_within_epoch_after_qc_proceed() {
+    // Set up 4 validators; we drive validator 0.
+    let private_keys: Vec<Arc<PrivateKey>> = (0..4)
+        .map(|_| Arc::new(PrivateKey::generate_for_testing()))
+        .collect();
+    let public_keys: Vec<PublicKey> = private_keys
+        .iter()
+        .map(|sk| PublicKey::from(sk.as_ref()))
+        .collect();
+    let addrs: Vec<AccountAddress> = (0..4).map(|_| AccountAddress::random()).collect();
+    let voting_powers: Vec<u64> = vec![1, 1, 1, 1];
+    let validator_consensus_infos: Vec<ValidatorConsensusInfo> = (0..4)
+        .map(|i| ValidatorConsensusInfo::new(addrs[i], public_keys[i].clone(), voting_powers[i]))
+        .collect();
+    let epoch_state = Arc::new(EpochState {
+        epoch: 1,
+        verifier: ValidatorVerifier::new(validator_consensus_infos.clone()).into(),
+    });
+
+    let update_certifier = DummyUpdateCertifier::default();
+    let vtxn_pool = VTxnPoolState::default();
+    let mut jwk_manager = JWKManager::new(
+        private_keys[0].clone(),
+        addrs[0],
+        epoch_state.clone(),
+        Arc::new(update_certifier),
+        vtxn_pool.clone(),
+    );
+
+    // Oracle-style issuer (gravity:// scheme). We never call
+    // reset_with_on_chain_state in this test, simulating the case where the
+    // chain doesn't emit ObservedJWKsUpdated for this source.
+    let issuer = issuer_from_str("gravity://0/1/events?contract=0xabc");
+    // For oracle sources, the JWK payload encodes the L1 nonce as 16-byte
+    // big-endian u128. convert_oracle_nonce reads exactly that.
+    let jwks_v1 = vec![oracle_jwk_with_nonce(1)];
+
+    // ─── Step 1: first observation (nonce = 1) ───
+    jwk_manager
+        .process_new_observation(issuer.clone(), jwks_v1.clone(), Some(1))
+        .unwrap();
+
+    // Sanity: state should be InProgress proposing version=1.
+    let state = jwk_manager.states_by_issuer.get(&issuer).unwrap();
+    assert!(
+        matches!(state.consensus_state, ConsensusState::InProgress { .. }),
+        "expected InProgress after first observation, got {:?}",
+        state.consensus_state.name()
+    );
+    let my_proposal_v1 = state.consensus_state.my_proposal_cloned();
+    assert_eq!(my_proposal_v1.observed.version, 1);
+
+    // ─── Step 2: simulate quorum cert produced + pool.put ───
+    let signer_bit_vec = BitVec::from(private_keys.iter().map(|_| true).collect::<Vec<_>>());
+    let sig_v1 = Signature::aggregate(
+        private_keys
+            .iter()
+            .map(|sk| sk.sign(&my_proposal_v1.observed).unwrap())
+            .collect::<Vec<_>>(),
+    )
+    .unwrap();
+    let qc_v1 = QuorumCertifiedUpdate {
+        update: my_proposal_v1.observed.clone(),
+        multi_sig: AggregateSignature::new(signer_bit_vec.clone(), Some(sig_v1)),
+    };
+    jwk_manager
+        .process_quorum_certified_update(qc_v1)
+        .expect("first QC should be accepted");
+
+    // ─── Step 3 (Fix A assertion): on_chain advances WITHOUT a chain reset ───
+    let state = jwk_manager.states_by_issuer.get(&issuer).unwrap();
+    assert!(
+        matches!(state.consensus_state, ConsensusState::Finished { .. }),
+        "expected Finished after QC, got {:?}",
+        state.consensus_state.name()
+    );
+    assert_eq!(
+        state.on_chain_version(),
+        1,
+        "Fix A: state.on_chain should be speculatively advanced to the certified \
+         version immediately after pool.put, even without an ObservedJWKsUpdated \
+         chain event."
+    );
+    // For oracle/bridge sources, the nonce reading must also reflect the new
+    // certified value (needs_update check uses convert_oracle_nonce, not the
+    // version field).
+    assert_eq!(
+        state.convert_oracle_nonce().unwrap(),
+        1,
+        "Fix A: convert_oracle_nonce must reflect the just-certified nonce so \
+         that the next observation's needs_update check sees an up-to-date \
+         baseline."
+    );
+
+    // ─── Step 4: second observation in the SAME epoch with nonce = 2 ───
+    // Before Fix A, on_chain_version would still be 0 here, the proposed
+    // version would be 1 (already on-chain), and the certifier would silently
+    // never form a quorum until the next epoch boundary. With Fix A, the
+    // proposed version is 2 (= on_chain + 1) and InProgress starts cleanly.
+    let jwks_v2 = vec![oracle_jwk_with_nonce(2)];
+    jwk_manager
+        .process_new_observation(issuer.clone(), jwks_v2, Some(2))
+        .unwrap();
+
+    let state = jwk_manager.states_by_issuer.get(&issuer).unwrap();
+    assert!(
+        matches!(state.consensus_state, ConsensusState::InProgress { .. }),
+        "Fix A: second observation in the same epoch must transition to \
+         InProgress (was previously silently stuck at Finished); got {:?}",
+        state.consensus_state.name()
+    );
+    let my_proposal_v2 = state.consensus_state.my_proposal_cloned();
+    assert_eq!(
+        my_proposal_v2.observed.version, 2,
+        "Fix A: proposed version must be on_chain_version + 1 = 2, not 1"
+    );
 }


### PR DESCRIPTION
## Summary

Fixes a bug where the 2nd+ cross-chain bridge message in any given epoch is delayed by up to one full `epoch_interval` (~2 hours on Gravity mainnet) before being committed to L2, even when all validators detect the source L1 event within milliseconds of one another.

Observed on Gravity mainnet 2026-05-19 during epoch 3:

| message | L1 nonce | richard-1 detect | L2 commit | end-to-end |
|--|--|--|--|--|
| #1 (1st in epoch) | 2 | 12:38:55 | 12:38:55 | ~0 s |
| #2 (2nd in epoch) | 3 | 13:10:55 | **13:56:36** | **45 min 41 s** |

All 5 active validators (Gravity core ×4 + richard-1) detected the nonce=3 event within an 80 ms window at 13:10:55, but no validator called `start_produce` for it until the epoch 3 → 4 transition fired at 13:56:35. Quorum cert formation and pool insertion then completed in under 50 ms.

## Root cause

`JWKManager::process_new_observation` decides whether to start a new cert cycle by comparing the observed nonce against `state.convert_oracle_nonce()` (which reads from `state.on_chain`), and it picks the proposed version as `state.on_chain_version() + 1`.

`state.on_chain` is refreshed only through `reset_with_on_chain_state`, which is driven by the on-chain `ObservedJWKsUpdated` event:

- For traditional OIDC JWK sources, this event is emitted by the on-chain `0x1::jwks` module on every JWK update, so `state.on_chain` stays in sync after each commit.
- For oracle / bridge sources (`gravity://`), the event is not guaranteed to fire on each commit, and empirically does not fire on Gravity mainnet as of 2026-05.

The result: after the first observation in an epoch is certified and pushed into `VTxnPool`, `state.on_chain` stays stale until the next epoch boundary recreates `JWKManager` from the latest chain state. Subsequent observations compute `new.version = stale_on_chain + 1`, collide with what is already on-chain at the same version, and silently fail to form a quorum cert. They release at the next epoch boundary in one batch.

## Fix A — speculative `state.on_chain` advancement for gravity:// sources

In `process_quorum_certified_update`, when the issuer is a `gravity://` source, advance `state.on_chain` to the just-certified `ProviderJWKs` immediately after `vtxn_pool.put`. This keeps the local state consistent with the about-to-commit chain state without depending on the `ObservedJWKsUpdated` event.

### Why gated to `gravity://`

For traditional JWK sources, `reset_with_on_chain_state` relies on a `cached == incoming` no-op short-circuit when an on-chain snapshot re-broadcasts the pre-update state (e.g., reconfig replays). If `state.on_chain` is pre-bumped to a newer post-QC version for those sources, the legitimate older snapshot looks "different" and replaces the valid `Finished` cert with a fresh `NotStarted`. The gate avoids that regression while still fixing the bridge path.

### Safety

Monotonic. `update.update.version` is `state.on_chain_version() + 1` at the time the `InProgress` state was created, so it strictly exceeds the previous `on_chain` version. Guarded with an explicit `>` check for defense in depth.

## Fix B — nonce-gap diagnostic warning

In `process_new_observation`, log a `warn!` when `observed_nonce > on_chain_version + 1`. This indicates the relayer caught up to multiple L1 events at once. The current code path only proposes the next contiguous version (using the data of a later event), which silently drops the intermediate events from the L2 commit history.

This is a diagnostic only — it does not change behavior. The deeper fix (queue events in the relayer and emit one at a time) is tracked in the companion issue linked below.

## Test plan

- New unit test `test_consecutive_observations_within_epoch_after_qc_proceed` reproduces the exact failure mode:
  1. Feed a `gravity://` observation at nonce 1
  2. Drive it to QC + `pool.put`
  3. Assert (Fix A) `state.on_chain_version() == 1` and `convert_oracle_nonce() == 1` *without* any `reset_with_on_chain_state` call
  4. Feed a second observation at nonce 2 in the same epoch
  5. Assert cert state transitions to `InProgress` with `proposed.version == 2`
- Pre-existing `test_jwk_manager_state_transition` continues to pass; the `gravity://` gate preserves the JWK path's behavior.

```
running 3 tests
test jwk_manager::tests::test_consecutive_observations_within_epoch_after_qc_proceed ... ok
test jwk_manager::tests::test_jwk_manager_state_transition ... ok
test observation_aggregation::tests::test_observation_aggregation_state ... ok

test result: ok. 3 passed; 0 failed
```

## Deployment

This is a single-binary fix — no chain config / governance / hard-fork required. Rolling restart of validators is sufficient. Verify post-deploy by sending two L1 bridge messages within the same epoch and confirming both commit within seconds of detection (rather than the second one waiting for the next epoch boundary).

## Companion issue

Tracks the deeper architectural questions (nonce-gap handling, optional separate `OracleConsensus` module for higher bridge throughput, on-chain `ObservedJWKsUpdated` emission for gravity:// sources). Filed in `gravity-sdk` because Issues are disabled on `gravity-aptos`:

- Galxe/gravity-sdk#724 — https://github.com/Galxe/gravity-sdk/issues/724

🤖 Generated with [Claude Code](https://claude.com/claude-code)